### PR TITLE
Log fedmsg tracebacks instead of discarding them.

### DIFF
--- a/kerneltest/dbtools.py
+++ b/kerneltest/dbtools.py
@@ -1,12 +1,13 @@
 # Licensed under the terms of the GNU GPL License version 2
 
 import datetime
-import warnings
 
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm import scoped_session
+
+import kerneltest.app
 
 BASE = declarative_base()
 
@@ -22,7 +23,7 @@ def fedmsg_publish(*args, **kwargs):  # pragma: no cover
         import fedmsg
         fedmsg.publish(*args, **kwargs)
     except Exception, err:
-        warnings.warn(str(err))
+        kerneltest.app.APP.logger.exception(err)
 
 
 class KernelTest(BASE):


### PR DESCRIPTION
This should help with figuring out whatever is going on on the prod nodes.

We see `/usr/lib/python2.7/site-packages/kerneltest/dbtools.py:25: UserWarning: [Errno 13] Permission denied: '/dev/ttyS3'`, but no further context in the logs.
