### PR TITLE
Fix some things to work with Python3

### DIFF
--- a/createdb.py
+++ b/createdb.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 ## These two lines are needed to run on EL6
 __requires__ = ['SQLAlchemy >= 0.7', 'jinja2 >= 2.4']
 import pkg_resources
@@ -39,4 +41,4 @@ SESSION.add(release)
 try:
     SESSION.commit()
 except SQLAlchemyError, err:
-    print err
+    print(err)

--- a/createdb.py
+++ b/createdb.py
@@ -40,5 +40,5 @@ SESSION.add(release)
 
 try:
     SESSION.commit()
-except SQLAlchemyError, err:
+except SQLAlchemyError as err:
     print(err)

--- a/harness.py
+++ b/harness.py
@@ -2,6 +2,7 @@
 #
 # Licensed under the terms of the GNU GPL License version 2
 
+from __future__ import print_function
 import os
 import string
 import time
@@ -39,7 +40,7 @@ def launchdomain(domain):
                break
             time.sleep(30)
         dom.create()
-    print "Domain %s started" % (domain)
+    print("Domain %s started" % (domain))
  
 if __name__ == '__main__':
     pidfile = open('/var/run/harness.pid', 'w')
@@ -66,7 +67,7 @@ if __name__ == '__main__':
                     writelatest(domain, package[1])
                     dom32 = domain + '32'
                     dom64 = domain + '64'
-                    print "starting domain %s" % (dom32)
+                    print("starting domain %s" % (dom32))
                     thread.start_new(launchdomain, (dom32,))
-                    print "starting domain %s" % (dom64)
+                    print("starting domain %s" % (dom64))
                     thread.start_new(launchdomain, (dom64,))

--- a/kerneltest/dbtools.py
+++ b/kerneltest/dbtools.py
@@ -21,7 +21,7 @@ def fedmsg_publish(*args, **kwargs):  # pragma: no cover
     try:
         import fedmsg
         fedmsg.publish(*args, **kwargs)
-    except Exception, err:
+    except Exception as err:
         import kerneltest.app
         kerneltest.app.APP.logger.exception(err)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,7 @@
 # Licensed under the terms of the GNU GPL License version 2
 
+from __future__ import print_function
+
 '''
 kerneltest tests.
 '''
@@ -35,7 +37,7 @@ if os.environ.get('BUILD_ID'):
         req = requests.get('%s/new' % FAITOUT_URL)
         if req.status_code == 200:
             DB_PATH = req.text
-            print 'Using faitout at: %s' % DB_PATH
+            print('Using faitout at: %s' % DB_PATH)
     except:
         pass
 
@@ -102,7 +104,7 @@ class Modeltests(unittest.TestCase):
                 db_name = DB_PATH.rsplit('/', 1)[1]
                 req = requests.get(
                     '%s/clean/%s' % (FAITOUT_URL, db_name))
-                print req.text
+                print(req.text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix a few simple things to work with Python3.
There a few other things that 2to3 reports needs fixing, but
the fixes for those are more involved.  We can do those later.
These fixes are simple.