### PR TITLE
Update for the changes to CLA / agreements in ipa/ipsilon

### DIFF
--- a/kerneltest/app.py
+++ b/kerneltest/app.py
@@ -83,7 +83,7 @@ def pre_request_user():
     if ui_view.oidc.user_loggedin:
         flask.g.user = User(
             ui_view.oidc.user_getfield("groups"),
-            ui_view.oidc.user_getfield("cla"),
+            "FPCA" in ui_view.oidc.user_getfield("agreements"),
             ui_view.oidc.user_getfield("nickname"),
         )
     else:

--- a/kerneltest/default_config.py
+++ b/kerneltest/default_config.py
@@ -30,7 +30,7 @@ DEFAULTS = dict(
         "openid",
         "profile",
         "https://id.fedoraproject.org/scope/groups",
-        "https://id.fedoraproject.org/scope/cla",
+        "https://id.fedoraproject.org/scope/agreements",
         "https://github.com/jmflinuxtx/kerneltest-harness/oidc/upload_test_run",
     ],
     LOG_CONFIG={


### PR DESCRIPTION
This updates the oidc scopes to the new agreements scope that will be
used when freeipa-fas / noggin is rolled out.

Signed-off-by: Ryan Lerch <rlerch@redhat.com>